### PR TITLE
Pass args '--upgrade-branch' for Cookiecutter template git branch name to run upgrade from

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Config file for automatic testing at travis-ci.org
 
 language: python
-dist: xenial
+dist: bionic
 
 install:
   - pip install -U tox

--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,11 @@ Usage: cookiecutter_project_upgrader [OPTIONS]
 Options:
   -c, --context-file PATH         Default: docs/cookiecutter_input.json
   -b, --branch TEXT               Default: cookiecutter-template
+  -u, --upgrade-branch TEXT       Optional branch name of cookiecutter
+                                  template to checkout before upgrading.
+                                  
+  -f, --zip-file TEXT             Zip file Path/URL for Cookiecutter templates.                                  
+
   -i, --interactive               Enter interactive mode. Default behaviour:
                                   skip questions, use defaults.
 

--- a/cookiecutter_project_upgrader/cli.py
+++ b/cookiecutter_project_upgrader/cli.py
@@ -3,6 +3,7 @@ import json
 import os
 from pathlib import Path
 from typing import Optional, Tuple
+from zipfile import ZipFile, BadZipFile
 
 from cookiecutter_project_upgrader.logic import update_project_template_branch
 
@@ -11,6 +12,9 @@ from cookiecutter_project_upgrader.logic import update_project_template_branch
 @click.option('--context-file', '-c', type=click.Path(file_okay=True, readable=True, allow_dash=True),
               default="docs/cookiecutter_input.json", help="Default: docs/cookiecutter_input.json")
 @click.option('--branch', '-b', default="cookiecutter-template", help="Default: cookiecutter-template")
+@click.option('--upgrade-branch', '-u',
+              help="Optional branch name of cookiecutter template to checkout before upgrading.")
+@click.option('--zip-file', '-f', help="Zip file Path/URL for Cookiecutter templates.")
 @click.option('--interactive', '-i', is_flag=True,
               help="Enter interactive mode. Default behaviour: skip questions, use defaults.")
 @click.option('--merge-now', '-m', type=bool, default=None,
@@ -20,16 +24,20 @@ from cookiecutter_project_upgrader.logic import update_project_template_branch
                    "default: ask if interactive, otherwise false.")
 @click.option('--exclude', '-e', type=str, multiple=True,
               help='Git pathspecs to exclude from the update commit, e.g. -e "*.py" -e "tests/".')
-def main(context_file: str, branch: str,
-         interactive: bool, merge_now: Optional[bool],
+def main(context_file: str, branch: str, upgrade_branch: Optional[str],
+         zip_file: Optional[str], interactive: bool, merge_now: Optional[bool],
          push_template_branch_changes: Optional[bool],
          exclude: Tuple[str, ...]):
     """Upgrade projects created from a Cookiecutter template"""
     context = _load_context(context_file)
+    if zip_file is not None and _is_valid_file(zip_file):
+        click.echo(f"Using zip-file: {zip_file} for upgrade.")
+        context['_template'] = zip_file
     project_directory = os.getcwd()
     update_project_template_branch(context,
                                    project_directory,
                                    branch,
+                                   upgrade_branch,
                                    merge_now,
                                    push_template_branch_changes,
                                    exclude,
@@ -45,3 +53,16 @@ def _load_context(context_file: str):
         exit(1)
     context = json.loads(context_str)
     return context
+
+
+def _is_valid_file(zip_file: str):
+    # we check only for local files for valid, for remote URLs, cookiecutter can do the test if its valid.
+    zip_path = Path(zip_file)
+    try:
+        if zip_path.exists():
+            ZipFile(Path(zip_file)).testzip()
+    except BadZipFile:
+        click.echo(f"Bad Zip file at: {zip_file}\n"
+                   f"Make sure your zip file is correct.")
+        exit(1)
+    return True

--- a/cookiecutter_project_upgrader/logic.py
+++ b/cookiecutter_project_upgrader/logic.py
@@ -46,7 +46,8 @@ def _git_repository_has_local_changes(git_repository: Path):
 
 
 def update_project_template_branch(context: MutableMapping[str, str], project_directory: str, branch: str,
-                                   merge_now: Optional[bool], push_template_branch_changes: Optional[bool],
+                                   upgrade_branch: Optional[str], merge_now: Optional[bool],
+                                   push_template_branch_changes: Optional[bool],
                                    exclude_pathspecs: Tuple[str, ...], interactive: bool):
     """Update template branch from a template url"""
     template_url = context['_template']
@@ -76,12 +77,15 @@ def update_project_template_branch(context: MutableMapping[str, str], project_di
     with _TemporaryGitWorktreeDirectory(tmp_git_worktree_directory, repo=project_directory, branch=branch):
         # update the template
         click.echo(f"Updating template in branch {branch} using extra_context={context}")
+        if upgrade_branch is not None:
+            click.echo(f"Updating from project remote branch={upgrade_branch}")
         click.echo("===========================================")
         cookiecutter(template_url,
                      no_input=True,
                      extra_context=context,
                      overwrite_if_exists=True,
-                     output_dir=tmp_directory)
+                     output_dir=tmp_directory,
+                     checkout=upgrade_branch)
         click.echo("===========================================")
         click.echo("Finished generating project from template.")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,9 @@
 from click.testing import CliRunner
 
 from cookiecutter_project_upgrader.cli import main
+from tests.tmp_files import CreateTempDirectory
+from pathlib import Path
+import subprocess
 
 
 def invoke(arguments):
@@ -26,3 +29,17 @@ def test_cli():
     invoke_successful(["--help"])
 
     invoke_failing(["--context-file", "./non-existing-file.py"])
+
+    # Test non existing zip file
+    invoke_failing(["--zip-file", "./non-existing-file.zip",
+                    "--context-file", "dummy_cookiecutter_template/cookiecutter.json"])
+
+    # Test bad existing zip file
+    with CreateTempDirectory("testzip") as testdir:
+        subprocess.run(["touch", "bad.zip"], cwd=Path(testdir), check=True)
+        invoke_failing(["--zip-file", str(testdir.joinpath("bad.zip")),
+                        "--context-file", "dummy_cookiecutter_template/cookiecutter.json"])
+
+    # Test non existing http url zip file
+    invoke_failing(["--zip-file", "http://test.com/non-existing-file.zip",
+                    "--context-file", "dummy_cookiecutter_template/cookiecutter.json"])

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -10,6 +10,8 @@ from click import ClickException
 from cookiecutter_project_upgrader.logic import update_project_template_branch
 from tests.files import copy_children
 from tests.tmp_files import CreateTempDirectory
+from zipfile import ZIP_DEFLATED, ZipFile
+from os.path import basename
 
 SAMPLE_CONTEXT = {
     "full_name": "Bernd Huber",
@@ -75,8 +77,9 @@ def test_initial_run_without_change_on_template_just_initializes_branch(cookiecu
 
     context = json.loads(project_directory.joinpath("docs", "cookiecutter_input.json").read_text(encoding="utf-8"))
     with pytest.raises(ClickException):
-        update_project_template_branch(context, str(project_directory), "cookiecutter-template", merge_now=None,
-                                       push_template_branch_changes=False, exclude_pathspecs=(), interactive=False)
+        update_project_template_branch(context, str(project_directory), "cookiecutter-template", "master",
+                                       merge_now=None, push_template_branch_changes=False,
+                                       exclude_pathspecs=(), interactive=False)
     subprocess.run(["git", "rev-parse", "cookiecutter-template"], cwd=str(project_directory), check=True)
 
 
@@ -103,7 +106,7 @@ def test_first_run_creates_branch_on_first_commit_and_updates_based_on_template(
     subprocess.run(["git", "commit", "-m", "updated readme"], cwd=str(cookiecutter_template_directory), check=True)
 
     context['_template'] = str(cookiecutter_template_directory)
-    update_project_template_branch(context, str(project_directory), "cookiecutter-template", merge_now=None,
+    update_project_template_branch(context, str(project_directory), "cookiecutter-template", "master", merge_now=None,
                                    push_template_branch_changes=False, exclude_pathspecs=(), interactive=False)
 
     subprocess.run(["git", "merge", "cookiecutter-template"], cwd=str(project_directory), check=True)
@@ -138,13 +141,54 @@ def test_change_project_slug(cookiecutter_template_directory: Path,
     old_project_slug = context['project_slug']
     new_project_slug = "my_new_name_for_project"
     context['project_slug'] = new_project_slug
-    update_project_template_branch(context, str(project_directory), "cookiecutter-template", merge_now=True,
+    update_project_template_branch(context, str(project_directory), "cookiecutter-template", "master", merge_now=True,
                                    push_template_branch_changes=False, exclude_pathspecs=(), interactive=False)
 
     readme = project_directory.joinpath("README.rst").read_text(encoding="utf-8")
     assert readme == "updated readme"
     assert project_directory.joinpath(new_project_slug).is_dir()
     assert not project_directory.joinpath(old_project_slug).exists()
+
+
+def test_changes_from_zip_file(cookiecutter_template_directory: Path,
+                               cookies: Cookies):
+    result: Result = cookies.bake(extra_context=SAMPLE_CONTEXT, template=str(cookiecutter_template_directory))
+    if result.exception is not None:
+        raise result.exception
+    project_directory = Path(result.project)
+    _initialize_git_repo(project_directory)
+    subprocess.run(["git", "add", "-A"], cwd=str(project_directory), check=True)
+    subprocess.run(["git", "commit", "-m", "initial"], cwd=str(project_directory), check=True)
+
+    context = json.loads(project_directory.joinpath("docs", "cookiecutter_input.json").read_text(encoding="utf-8"))
+
+    cookiecutter_template_directory.joinpath("{{cookiecutter.project_slug}}",
+                                             "README.rst").write_text("updated readme for zip test")
+    subprocess.run(["git", "add", "-A"], cwd=str(cookiecutter_template_directory), check=True)
+    subprocess.run(["git", "commit", "-m", "updated readme for zip test"],
+                   cwd=str(cookiecutter_template_directory), check=True)
+
+    # Pack dummy template to zip file
+    zipfile_path = ''
+    with CreateTempDirectory("testzip") as testdir:
+        zipfile_path = str(testdir.joinpath(basename(cookiecutter_template_directory)+".zip"))
+
+        with ZipFile(str(zipfile_path), 'w', ZIP_DEFLATED) as zip:
+            # this line is needed for cookiecutter zip verification
+            zip.write(cookiecutter_template_directory, str(basename(cookiecutter_template_directory)))
+            for folderName, subfolders, filenames in os.walk(cookiecutter_template_directory):
+                for filename in filenames:
+                    filePath = os.path.join(folderName, filename)
+                    zip.write(filePath, str(filePath).replace(str(cookiecutter_template_directory),
+                              basename(str(cookiecutter_template_directory))))
+
+        context['_template'] = str(zipfile_path)
+        update_project_template_branch(context, str(project_directory), "cookiecutter-template", "master",
+                                       merge_now=True, push_template_branch_changes=False, exclude_pathspecs=(),
+                                       interactive=False)
+
+    readme = project_directory.joinpath("README.rst").read_text(encoding="utf-8")
+    assert readme == "updated readme for zip test"
 
 
 def test_exclude_paths(cookiecutter_template_directory: Path,
@@ -162,7 +206,7 @@ def test_exclude_paths(cookiecutter_template_directory: Path,
     context['_template'] = str(cookiecutter_template_directory)
     context['project_slug'] = 'a_new_name'
 
-    update_project_template_branch(context, str(project_directory), "cookiecutter-template", merge_now=True,
+    update_project_template_branch(context, str(project_directory), "cookiecutter-template", "master", merge_now=True,
                                    push_template_branch_changes=False, exclude_pathspecs=("README.rst",),
                                    interactive=False)
 

--- a/tox.ini
+++ b/tox.ini
@@ -37,4 +37,4 @@ skip_install = true
 [testenv:mypy]
 basepython = python
 extras = dev
-commands = mypy {[globals]source_folder} tests
+commands = mypy {[globals]source_folder} tests/__init__.py  tests/files.py  tests/test_cli.py  tests/test_logic.py  tests/tmp_files.py


### PR DESCRIPTION
I need logic to be able to pass branch name for git repo of cookiecutter template when upgrading projects. 
I've added an additional argument that can be passed to cli and to cookiecutter checkout param. Default will be 'master' - the default for cookiecutter.
As default branch will be master, it will not impact existing functionality.